### PR TITLE
os.manage shouldn't ask for minutes if no appropriate option was selected 

### DIFF
--- a/R/os.manage.r
+++ b/R/os.manage.r
@@ -215,6 +215,8 @@ os.manage  <- function(use_GUI = TRUE, ask = TRUE, ...) {
    
    the_answer <- menu(choices, graphics = use_GUI, title = "Manage your OS (for Windows)")            
    
+   if (the_answer==0 || choices[the_answer]=="Cancel") return(FALSE)
+   
    # in how many minutes to perform the operation?
    if(ask) minutes <- 
       winDialogString(      


### PR DESCRIPTION
Function os.manage shouldn't ask for minutes if 'Cancel' is selected or window was closed without selecting any option. (I got nervous that my computer would shut down unintentionally when I was asked this second question after choosing 'Cancel'.)
