### PR TITLE
fixed cygwin

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -978,7 +978,7 @@ install.Cygwin  <- function(bit = 32, ...) {
       install.URL("http://cygwin.com/setup-x86.exe", ...)
    }
 
-   if(bit == 32){
+   if(bit == 64){
       install.URL("http://cygwin.com/setup-x86_64.exe", ...)
    }
 


### PR DESCRIPTION
The install.Cygwin command was not performing correctly with bit = 64.  Probably copy-paste error.

Thanks for the package.