### PR TITLE
updated install.python() to check 32/64 bit Windows and checked re-bu…

### DIFF
--- a/R/installPython.R
+++ b/R/installPython.R
@@ -20,13 +20,14 @@
 #' @description Downloads and installs the latest version of python 2 or 3 for Windows.
 #' @details
 #' Python is a programming language which has two versions under active development. 
-#' Make sure you know which version is required for the code you have to run, or alternatively, make sure you are developing code that is fit for your chosen version of Python.
+#' Make sure you know which version is required for the code you have to run, or alternatively, make sure you are developing code that is fit for your chosen version of Python. In addition, the Python installers are specific to 32 or 64 bit windows architectures. 
 #' 
 #' @return TRUE/FALSE - was the installation successful or not.
 #' @export
 #' @author Tal Galili and A. Jonathan R. Godfrey
 #' @param page_with_download_url a link to the list of download links for Python
-#' @param version_number Either 2 or 3. Version 2 will lead to download of v2.7.xxx
+#' @param x64 logical: fetch a 64 bit version. default checks architecture of current R session.
+#' @param version_number Either 2 or 3. Version 2/3 will lead to download of v2.7.xx/3.6.xx respectively.
 #' @param ... extra parameters to pass to \link{install.URL}
 #' @examples
 #' \dontrun{
@@ -36,6 +37,7 @@
 #' }
 install.python = function (page_with_download_url = "https://www.python.org/downloads/windows/",
                            version_number = 3,
+                           x64 = is.x64(),
                              ...)
 {
   page <- readLines(page_with_download_url, warn = FALSE)
@@ -54,7 +56,11 @@ install.python = function (page_with_download_url = "https://www.python.org/down
 							"2" = "msi",
 							"3" = "exe")
   URL <- paste0("https://www.python.org/ftp/python/",VersionNo, "/python-",VersionNo  , ".", file_extension)[1]
-  
+  if(x64){ #different filenames for P3  Py27#Py3
+    URL <- sub(".exe", "-amd64.exe", URL)  #Py3
+    URL <- sub(".msi", ".amd64.msi", URL)  #Py2.7
+  }  
+
   install.URL(URL, ...) 
 }
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ installr() #  user can easily select (via a GUI interface) a software to install
 
 ## Troubleshooting
 
-If you one of the followiong errors from some commands:
+If you get either of the following errors from some commands:
 
 ```r
 Error in download.file(URL, destfile = ...) : 

--- a/man/install.python.Rd
+++ b/man/install.python.Rd
@@ -6,12 +6,14 @@
 \usage{
 
   install.python(page_with_download_url = "https://www.python.org/downloads/windows/",
-  version_number = 3, ...)
+  version_number = 3, x64 = is.x64(), ...)
 }
 \arguments{
 \item{page_with_download_url}{a link to the list of download links for Python}
 
-\item{version_number}{Either 2 or 3. Version 2 will lead to download of v2.7.xxx}
+\item{version_number}{Either 2 or 3. Version 2/3 will lead to download of v2.7.xx/3.6.xx respectively.}
+
+\item{x64}{logical: fetch a 64 bit version. default checks architecture of current R session.}
 
 \item{...}{extra parameters to pass to \link{install.URL}}
 }
@@ -23,7 +25,7 @@ Downloads and installs the latest version of python 2 or 3 for Windows.
 }
 \details{
 Python is a programming language which has two versions under active development. 
-Make sure you know which version is required for the code you have to run, or alternatively, make sure you are developing code that is fit for your chosen version of Python.
+Make sure you know which version is required for the code you have to run, or alternatively, make sure you are developing code that is fit for your chosen version of Python. In addition, the Python installers are specific to 32 or 64 bit windows architectures.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
…ild of package

added an argument to install.python() for x64 status, using is.x64().
This adds a (different) string to each of the URLs needed to download Python 2.7.x or 3.6.x
Also found a grammatical error in the readme.md