### PR TITLE
Fix install.Rtools

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,6 +57,7 @@ Suggests:
     plyr,
     ggplot2,
     sp,
-    tools
+    tools,
+    pkgbuild
 License: GPL-2
 RoxygenNote: 6.1.0

--- a/R/install.R
+++ b/R/install.R
@@ -499,7 +499,7 @@ install.Rtools <- function(choose_version = FALSE,
    # latest_Frozen==F means we get the latest Rtools version which is not Frozen (when writing this function it is Rtools30.exe)
 
    if(check & requireNamespace("devtools")) { # if we have devtools we can check for the existance of rtools
-      found_rtools <- devtools::find_rtools()
+      found_rtools <- pkgbuild::find_rtools()
       if(found_rtools) {
          cat("No need to install Rtools - You've got the relevant version of Rtools installed\n")
          return(invisible(FALSE))

--- a/R/install.R
+++ b/R/install.R
@@ -498,7 +498,7 @@ install.Rtools <- function(choose_version = FALSE,
    # latest_Frozen==T means we get the latest Rtools version which is Frozen (when writing this function it is Rtools215.exe)
    # latest_Frozen==F means we get the latest Rtools version which is not Frozen (when writing this function it is Rtools30.exe)
 
-   if(check & requireNamespace("devtools")) { # if we have devtools we can check for the existance of rtools
+   if(check & requireNamespace("pkgbuild")) { # if we have devtools we can check for the existance of rtools
       found_rtools <- pkgbuild::find_rtools()
       if(found_rtools) {
          cat("No need to install Rtools - You've got the relevant version of Rtools installed\n")


### PR DESCRIPTION
The function install.Rtools wasn't working, because the function find_rtools() has been moved from package devtools to pkgbuild. So it is necessary to reflect that change in installr.

