### PR TITLE
fix no-args bug in `create.global.library`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,6 +64,8 @@ Suggests:
     sp,
     tools,
     pkgbuild,
+    testthat (>= 2.1.0),
+    mockery,
     R.utils
 License: GPL-2
 RoxygenNote: 6.1.1

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@ OTHER NOTES:
 
 BUG FIXES:
    * Fix install.GraphicsMagick
+   * Fix create.global.library to allow no arguments
 
 
 installr 0.22.0 (2019-08-02)

--- a/R/create.global.library.R
+++ b/R/create.global.library.R
@@ -77,29 +77,48 @@
 create.global.library <- function(global_library_folder)
 {
    # global_library_folder = "C:/Program Files/R/library"
-   # global_library_folder is null then if we assume it is of the shape: # "C:/Program Files/R/library"
-   
-   # Step 1: In case it is not defined - decide what the global folder is.   
-   if(missing(global_library_folder) | is.null(global_library_folder))  {  # then decide what it should be
-      # finding the parent directoy of R (into which we will add the library directory)
-      R_parent_lib <- paste(head(strsplit(R.home(), "/|\\\\")[[1]], -1), collapse = "/") # the strsplit is seperating the path whether it is / or \\ (but since \\ is a problem, I need to cancel it with \\\\)      
-      # if global_library_folder isn't defined, then we assume it is of the form: "C:\\Program Files\\R\\library"
-      global_library_folder <- file.path(R_parent_lib, "library")         
-      cat("global_library_folder wasn't specified, and is set by default to be: ", global_library_folder, "\n")
-   }   
-   
+   # global_library_folder is null then if we assume it is of the shape: #
+   # "C:/Program Files/R/library"
+
+   # Step 1: In case it is not defined - decide what the global folder is.
+   if (missing(global_library_folder) || is.null(global_library_folder))  {
+      # then decide what it should be
+      # finding the parent directoy of R (into which we will add the library
+      # directory)
+      R_parent_lib <- dirname(R.home())
+      # if global_library_folder isn't defined, then we assume it is of the
+      # form: "C:\\Program Files\\R\\library"
+      global_library_folder <- file.path(R_parent_lib, "library")
+      message(
+         "global_library_folder wasn't specified, and is set by default to be: ",
+         global_library_folder, "\n"
+      )
+   }
+
    # Step 2: check if the global lib folder exists -
    # if not -> create it.
-   if(file.exists(global_library_folder)) # no better solution: http://stackoverflow.com/questions/4216753/check-existence-of-directory-and-create-if-doesnt-exist
-   {   
-      cat(paste("The path:" , global_library_folder, "already exist. (no need to create it) \n"))
-      did_we_create_global_library_folder <- F
-   } else { # If global lib folder doesn't exist - create it.
-      dir.create(global_library_folder)
-      did_we_create_global_library_folder <- T
+   if (file.exists(global_library_folder)) # no better solution: http://stackoverflow.com/questions/4216753/check-existence-of-directory-and-create-if-doesnt-exist
+   {
+      message(
+         "The path: " , global_library_folder, " already exist. (no need to",
+         "create it) \n"
+      )
+      did_we_create_global_library_folder <- FALSE
+   } else {
+      # If global lib folder doesn't exist - create it if you can.
+      tryCatch(
+         expr = {
+            dir.create(global_library_folder)
+         },
+         finally = {
+            did_we_create_global_library_folder <- dir.exists(
+               global_library_folder
+            )
+         }
+      )
    }
-   
-   return(did_we_create_global_library_folder)
+
+   did_we_create_global_library_folder
 }
 
 
@@ -110,7 +129,7 @@ create.global.library <- function(global_library_folder)
 
 xx.global.library <- function(
                                   copy_packges_to_global_library_folder = F, # should be T if this is the first time you are running this (either from the old or the new version of R you have just installed).
-                                  # copy_packages_from_old_R_installation = F, # should be T if you are running this for the first time, from a new installation of R, after having an old installation of R (where all of your old packages are)                                  
+                                  # copy_packages_from_old_R_installation = F, # should be T if you are running this for the first time, from a new installation of R, after having an old installation of R (where all of your old packages are)
                                   del_packages_that_exist_in_home_lib = F,
                                   update_all_packages = T,
                                   global_library_folder = NULL,
@@ -119,11 +138,11 @@ xx.global.library <- function(
 {
    # global_library_folder = "C:/Program Files/R/library"
    # global_library_folder is null then if we assume it is of the shape: # "C:/Program Files/R/library"
-   
+
    did_we_create_global_library_folder <- create.global.library(global_library_folder)
-   
-   R_parent_lib <- paste(head(strsplit(R.home(), "/|\\\\")[[1]], -1), collapse = "/") # the strsplit is seperating the path whether it is / or \\ (but since \\ is a problem, I need to cancel it with \\\\)      
-   
+
+   R_parent_lib <- paste(head(strsplit(R.home(), "/|\\\\")[[1]], -1), collapse = "/") # the strsplit is seperating the path whether it is / or \\ (but since \\ is a problem, I need to cancel it with \\\\)
+
    # Step 3: Create a list of all the packages we have in the current .libPaths (shouldn't include the new folder, but just in case - we'll take care of that soon)
    # Copy packages from current lib folder to the global lib folder
 
@@ -134,16 +153,16 @@ xx.global.library <- function(
       cat("Do you have packages from on OLD installation of R (not the one you are running this script from)\n from which you'd like to move packages into: " , global_library_folder, "  \n")
       answer <- readline("y(es)/n(o): ")
       if(substr(tolower(answer), 1,1) == "y") {
-         # I am just going to ask the user 
+         # I am just going to ask the user
          # I am NOT going to assume that the latest version of R is the last folder.  And that the previous version of R is the folder before it.
          old_R_folders <- data.frame(Folders = list.files(R_parent_lib), stringsAsFactors=F)
-         ROW_id <- ask.user.for.a.row(old_R_folders, 
-                                      header_text = 
+         ROW_id <- ask.user.for.a.row(old_R_folders,
+                                      header_text =
                                          paste("From which of the following R folders \n would you like to copy your old packages to ",global_library_folder, " ?"))
          the_libPaths <- c(file.path(R_parent_lib, old_R_folders[ROW_id, 1], "library"),
                            the_libPaths) # add this old version of R to the pool of places to check.
-      } 
-      
+      }
+
       number_of_lib_dir <- length(the_libPaths)
       for(i in seq_len(number_of_lib_dir))
       {
@@ -152,41 +171,41 @@ xx.global.library <- function(
                                paste( the_libPaths[i],"/", list.files(the_libPaths[i]),sep = "")
          )
       }
-      
+
       packages_in_global_library_folder <- list.files(global_library_folder) # should be empty if we have just created this folder for the first time
-            
+
       # Step 4: check if the current (old) library folder has any packages we might wish to move. e.g: non-"high" packages (e.g: packages installed after R was installed), or packages in the global_library_folder
       packages_to_NOT_move <- c(installed.packages(priority = "high")[,"Package"], # some context on "high" packages: http://stackoverflow.com/questions/9700799/what-is-difference-between-r-base-and-r-recommended-packages
                                 packages_in_global_library_folder)  # we wish to NOT move into the global directory packages which are from "base R", and packages which are ALREADY in the packages_in_global_library_folder.
       names_of_packages_in_libs <- sapply(strsplit(packages_in_libs, "/|\\\\"), function(x) tail(x, 1))  # this is stripping the last location from each folder (hence: the package name)
       ss_packages_to_NOT_move_froms_libs <- names_of_packages_in_libs %in%  packages_to_NOT_move
       packages_in_libs_to_move <- packages_in_libs[!ss_packages_to_NOT_move_froms_libs]
-      
-      
+
+
       # COPY old packages to the new global folder:
       cat("-----------------------","\n")
       cat("I am now copying ", length(packages_in_libs_to_move) ," packages from the old librarys folders' to:","\n")
       cat(global_library_folder,"\n")
       cat("-----------------------","\n")
       flush.console()  # refresh the console so that the user will see the message
-      
+
       folders.copied <- file.copy(from = packages_in_libs_to_move,    # copy folders
                                   to = global_library_folder,
                                   overwrite = TRUE,
                                   recursive =TRUE)
-      
+
       cat("Success.","\n")
       cat(paste("We finished copying all of your packages (" , sum(folders.copied), "packages ) to the new library folder at:"),"\n")
       cat(global_library_folder,"\n")
-      cat("-----------------------","\n")     
-      
-      
-   }   
-   
-   
+      cat("-----------------------","\n")
+
+
+   }
+
+
    #####################################################
    #####################################################
-   
+
    # Based on:
    # help(Startup)
    # checking if "Renviron.site" exists - and if not -> create it.
@@ -194,39 +213,39 @@ xx.global.library <- function(
    if(!file.exists(Renviron.site.loc))
    {   # If "Renviron.site" doesn't exist (which it shouldn't be) - create it and add the global lib line to it.
       cat(paste("R_LIBS='",global_library_folder, "'\n",sep = "") ,
-          file = Renviron.site.loc)				 
+          file = Renviron.site.loc)
       cat(paste("The file:" , Renviron.site.loc, "Didn't exist - we created it and added your 'Global library link' (",global_library_folder,") to it.\n"))
    } else {
       cat(paste("The file:" , Renviron.site.loc, "existed and we could NOT add some lines!  make sure you add the following line by yourself:","\n"))
       cat(paste("R_LIBS=",global_library_folder,"\n", sep = "") )
       cat(paste("To the file:",Renviron.site.loc,"\n"))
    }
-   
-   
-   
+
+
+
    # Setting the global lib for this session also
    .libPaths(global_library_folder)	# This makes sure you don't need to restart R so that the new Global lib settings will take effect in this session also
    # .libPaths(new="C:/PROGRA~1/R/library")
    # .libPaths()
    # This line could have also been added to:
-   
-   # /etc/Rprofile.site
-   
-   # and it would do the same thing as adding "Renviron.site" did
-   
-   cat("Your library paths are: ","\n")
-   cat(.libPaths(),"\n")	
-   flush.console()  # refresh the console so that the user will see the message
-   
 
-   
+   # /etc/Rprofile.site
+
+   # and it would do the same thing as adding "Renviron.site" did
+
+   cat("Your library paths are: ","\n")
+   cat(.libPaths(),"\n")
+   flush.console()  # refresh the console so that the user will see the message
+
+
+
    if(del_packages_that_exist_in_home_lib)
    {
       cat("We will now delete package from your Global library folder that already exist in the local-install library folder","\n")
       flush.console()  # refresh the console so that the user will see the message
       package.to.del.from.global.lib <- 		paste( paste(global_library_folder, "/", sep = ""),
                                                  list.files(paste(R.home(), "\\library\\", sep = "")),
-                                                 sep = "")			
+                                                 sep = "")
       # this code can be made nicer
       packages_in_libs <- package.to.del.from.global.lib
       file.path(R.home(), "library", installed.packages(priority = "high")[,"Package"])
@@ -234,19 +253,19 @@ xx.global.library <- function(
       names_of_packages_in_libs <- sapply(strsplit(packages_in_libs, "/|\\\\"), function(x) tail(x, 1))  # this is stripping the last location from each folder (hence: the package name)
       ss_packages_to_NOT_move_froms_libs <- names_of_packages_in_libs %in%  packages_to_NOT_move
       packages_in_libs_to_move <- packages_in_libs[!ss_packages_to_NOT_move_froms_libs]
-      
+
       package.to.del.from.global.lib <- packages_in_libs_to_move
-      
+
       number.of.packages.we.will.delete <- length(package.to.del.from.global.lib)
       if(package.to.del.from.global.lib >0 ) {
          # maybe add a user input here...
-         deleted.packages <- unlink(package.to.del.from.global.lib , recursive = TRUE)   # delete all the packages from the "original" library folder (no need for double folders)      
+         deleted.packages <- unlink(package.to.del.from.global.lib , recursive = TRUE)   # delete all the packages from the "original" library folder (no need for double folders)
          cat(paste(number.of.packages.we.will.delete,"Packages where deleted."),"\n")
       }
    }
-   
-   
-   
+
+
+
    if(update_all_packages)
    {
       # Based on:
@@ -255,8 +274,8 @@ xx.global.library <- function(
       flush.console()  # refresh the console so that the user will see the message
       update.packages(checkBuilt=TRUE, ask=FALSE)
    }
-   
-   
+
+
    # To quite R ?
    if(missing(quit_R))
    {
@@ -312,7 +331,7 @@ Old.R.RunMe <- function(global.library.folder = NULL, quit.R = NULL)
 {
    # global.library.folder = "C:/Program Files/R/library"
    # global.library.folder is null then if we assume it is of the shape: # "C:/Program Files/R/library"
-   
+
    if(is.null(global.library.folder))
    {
       # finding the parent directoy of R (into which we will add the library directory)
@@ -322,10 +341,10 @@ Old.R.RunMe <- function(global.library.folder = NULL, quit.R = NULL)
       { R_parent_lib <- paste(head(strsplit(R.home(), "\\", fixed = T)[[1]], -1), collapse = "/") }
       # if global.library.folder isn't defined, then we assume it is of the form: "C:\\Program Files\\R\\library"
       global.library.folder <- paste(R_parent_lib, "/library", sep = "")
-   }	
-   
+   }
+
    # checking that the global lib folder exists - and if not -> create it.
-   
+
    if(!file.exists(global.library.folder))
    {	# If global lib folder doesn't exist - create it.
       dir.create(global.library.folder)
@@ -333,14 +352,14 @@ Old.R.RunMe <- function(global.library.folder = NULL, quit.R = NULL)
    } else {
       cat(paste("The path:" , global.library.folder, "already exist. (no need to create it)","\n"))
    }
-   
-   
+
+
    cat("-----------------------","\n")
    cat("I am now copying packages from old library folder to:","\n")
    cat(global.library.folder,"\n")
    cat("-----------------------","\n")
    flush.console()  # refresh the console so that the user will see the message
-   
+
    # Copy packages from current lib folder to the global lib folder
    list.of.dirs.in.lib <- NULL
    number_of_lib_dir <- length(.libPaths())
@@ -355,21 +374,21 @@ Old.R.RunMe <- function(global.library.folder = NULL, quit.R = NULL)
    # list.of.dirs.in.lib <- paste( paste(R.home(), "\\library\\", sep = ""),
    # list.files(paste(R.home(), "\\library\\", sep = "")),
    # sep = "")
-   
+
    folders.copied <- file.copy(from = list.of.dirs.in.lib, 	# copy folders
                                to = global.library.folder,
                                overwrite = TRUE,
-                               recursive =TRUE)		
-   
-   
-   
+                               recursive =TRUE)
+
+
+
    cat("Success.","\n")
    cat(paste("We finished copying all of your packages (" , sum(folders.copied), "packages ) to the new library folder at:"),"\n")
    cat(global.library.folder,"\n")
    cat("-----------------------","\n")
-   
-   
-   
+
+
+
    # To quite R ?
    if(is.null(quit.R))
    {
@@ -395,14 +414,14 @@ Old.R.RunMe <- function(global.library.folder = NULL, quit.R = NULL)
 
 
 
-New.R.RunMe <- function (global.library.folder = NULL, 
+New.R.RunMe <- function (global.library.folder = NULL,
                          quit.R = F,
                          del.packages.that.exist.in.home.lib = F,
                          update.all.packages = T)
-   
+
 {
-   
-   
+
+
    if(is.null(global.library.folder))
    {
       # finding the parent directoy of R (into which we will add the library directory)
@@ -412,9 +431,9 @@ New.R.RunMe <- function (global.library.folder = NULL,
       { R_parent_lib <- paste(head(strsplit(R.home(), "\\", fixed = T)[[1]], -1), collapse = "/") }
       # if global.library.folder isn't defined, then we assume it is of the form: "C:\\Program Files\\R\\library"
       global.library.folder <- paste(R_parent_lib, "/library", sep = "")
-   }	
-   
-   
+   }
+
+
    # checking that the global lib folder exists - and if not -> create it. (happens if it is the first time running New.R.RunMe)
    if(!file.exists(global.library.folder))
    {	# If global lib folder doesn't exist - create it.
@@ -423,13 +442,13 @@ New.R.RunMe <- function (global.library.folder = NULL,
    } else {
       cat(paste("The path to the Global library (" , global.library.folder, ") already exist. (NO need to create it)"),"\n")
    }
-   
+
    flush.console()  # refresh the console so that the user will see the message
-   
-   
-   
-   
-   
+
+
+
+
+
    # Based on:
    # help(Startup)
    # checking if "Renviron.site" exists - and if not -> create it.
@@ -437,49 +456,49 @@ New.R.RunMe <- function (global.library.folder = NULL,
    if(!file.exists(Renviron.site.loc))
    {	# If "Renviron.site" doesn't exist (which it shouldn't be) - create it and add the global lib line to it.
       cat(paste("R_LIBS='",global.library.folder, "'\n",sep = "") ,
-          file = Renviron.site.loc)				 
+          file = Renviron.site.loc)
       cat(paste("The file:" , Renviron.site.loc, "Didn't exist - we created it and added your 'Global library link' (",global.library.folder,") to it.\n"))
    } else {
       cat(paste("The file:" , Renviron.site.loc, "existed and we could NOT add some lines!  make sure you add the following line by yourself:","\n"))
       cat(paste("R_LIBS=",global.library.folder,"\n", sep = "") )
       cat(paste("To the file:",Renviron.site.loc,"\n"))
    }
-   
-   
-   
+
+
+
    # Setting the global lib for this session also
    .libPaths(global.library.folder)	# This makes sure you don't need to restart R so that the new Global lib settings will take effect in this session also
    # .libPaths(new="C:/PROGRA~1/R/library")
    # .libPaths()
    # This line could have also been added to:
-   
+
    # /etc/Rprofile.site
-   
+
    # and it would do the same thing as adding "Renviron.site" did
-   
+
    cat("Your library paths are: ","\n")
-   cat(.libPaths(),"\n")	
+   cat(.libPaths(),"\n")
    flush.console()  # refresh the console so that the user will see the message
-   
-   
-   
-   
-   
+
+
+
+
+
    if(del.packages.that.exist.in.home.lib)
    {
       cat("We will now delete package from your Global library folder that already exist in the local-install library folder","\n")
       flush.console()  # refresh the console so that the user will see the message
       package.to.del.from.global.lib <- 		paste( paste(global.library.folder, "/", sep = ""),
                                                  list.files(paste(R.home(), "\\library\\", sep = "")),
-                                                 sep = "")			
+                                                 sep = "")
       number.of.packages.we.will.delete <- sum(list.files(paste(global.library.folder, "/", sep = "")) %in% list.files(paste(R.home(), "\\library\\", sep = "")))
       deleted.packages <- unlink(package.to.del.from.global.lib , recursive = TRUE)	# delete all the packages from the "original" library folder (no need for double folders)
-      
+
       cat(paste(number.of.packages.we.will.delete,"Packages where deleted."),"\n")
    }
-   
-   
-   
+
+
+
    if(update.all.packages)
    {
       # Based on:
@@ -488,11 +507,11 @@ New.R.RunMe <- function (global.library.folder = NULL,
       flush.console()  # refresh the console so that the user will see the message
       update.packages(checkBuilt=TRUE, ask=FALSE)
    }
-   
+
    # To quite R ?
-   
+
    if(quit.R) quit(save = "no")
-   
+
 }
 
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(installr)
+
+test_check("installr")

--- a/tests/testthat/test-create_global_library.R
+++ b/tests/testthat/test-create_global_library.R
@@ -1,0 +1,130 @@
+context("Test that a global-library for R packages can be constructed")
+
+test_that("A User-specified dir can be used as a global-library", {
+   td <- tempdir()
+
+   # create a directory for use as a global-library
+   # - ensure the directory exists before calling create.global.library
+   # - then check that the dir can be used as a global library
+   pre_existing <- file.path(td, "cr.gl.lib.pre-existing-user-dir")
+   dir.create(pre_existing)
+   stopifnot(dir.exists(pre_existing))
+
+   expect_false(
+      create.global.library(pre_existing),
+      info = "create.global.library did not need to construct the library"
+   )
+   expect_true(
+      dir.exists(pre_existing),
+      info = paste(
+         "the (pre-existing) dir exists after calling create.global.library"
+      )
+   )
+
+   # specify a directory for use as a global library
+   # - ensure that the directory does not exist before calling
+   # create.global.library
+   # - then check that the dir can be used as a global library and that it
+   # exists after calling create.global.library
+   non_existing <- file.path(td, "cr.gl.lib.non-existing-user-dir")
+   if (dir.exists(non_existing)) {
+      unlink(non_existing, recursive = TRUE)
+   }
+   if (dir.exists(non_existing)) {
+      stop("can't remove a pre-existing directory using unlink()")
+   }
+
+   expect_true(
+      create.global.library(non_existing),
+      info = "create.global.library did need to construct the library"
+   )
+   expect_true(
+      dir.exists(non_existing),
+      info = paste(
+         "after calling create.global.library, a previously non-existing dir",
+         "now exists"
+      )
+   )
+})
+
+test_that(
+   "If no user-specified global-library is provided, use `<R.home>/../library`",
+   {
+      td <- tempdir()
+
+      # On windows
+      # - typical R installations are stored in
+      # R.home() = "<path to program-files>/R/R-3.6.1"
+      # - ... and we make a global library in "<path to program-files>/R/library"
+
+      # When the global library does not already exist:
+      test_dir <- file.path(td, "cr.gl.lib.non-existing-default-dir")
+      mock_r_home <- file.path(test_dir, "R", "R-3.6.1")
+      expected_global_library <- file.path(test_dir, "R", "library")
+
+      dir.create(mock_r_home, recursive = TRUE)
+      stopifnot(dir.exists(mock_r_home))
+      if (dir.exists(expected_global_library)) {
+         unlink(expected_global_library)
+      }
+      if (dir.exists(expected_global_library)) {
+         stop("Couldn't unlink a pre-existing dir")
+      }
+
+      mockery::stub(create.global.library, "R.home", mock_r_home)
+      expect_true(
+         create.global.library(),
+         info = "create.global.library should make the default global library"
+      )
+      expect_true(
+         dir.exists(expected_global_library),
+         info = paste(
+            "default-global-library exists after running create.global.library",
+            "with no args"
+         )
+      )
+   }
+)
+
+test_that(
+   "If the global-library cannot be created, throw a warning",
+   {
+      td <- tempdir()
+
+      # On windows
+      # - typical R installations are stored in
+      # R.home() = "<path to program-files>/R/R-3.6.1"
+      # - ... and we make a global library in "<path to program-files>/R/library"
+
+      # When the global library does not already exist:
+      test_dir <- file.path(td, "cr.gl.lib.unwriteable-dir")
+      mock_r_home <- file.path(test_dir, "R", "R-3.6.1")
+      expected_global_library <- file.path(test_dir, "R", "library")
+
+      dir.create(mock_r_home, recursive = TRUE)
+      stopifnot(dir.exists(mock_r_home))
+      if (dir.exists(expected_global_library)) {
+         stop("library should not already exist")
+      }
+
+      mockery::stub(create.global.library, "R.home", mock_r_home)
+      mockery::stub(create.global.library, "dir.create", function(d) {
+         warning("cannot create dir", d, ", reason 'Permission denied'")
+         FALSE
+      })
+
+      expect_warning(
+         create.global.library(),
+         info = paste(
+            "create.global.library should throw a warning if it can't make",
+            "the global library"
+         )
+      )
+      expect_false(
+         dir.exists(expected_global_library),
+         info = paste(
+            "global-library can't be created in an unwriteable dir"
+         )
+      )
+   }
+)


### PR DESCRIPTION
`create.global.library(global_library_folder)` was failing when passed
no arguments. The expression

```
missing(global_library_folder) | is.null(global_library_folder)
```

was evaluting both sides of the `|` operator - this has been replaced
with a `||` operator (so `is.null(...)` is only evaluated when
`global_library_folder` is not missing).

Tests (and testthat/mockery dependencies) have been added to ensure that
- a user-specified global-library can be used,
- a no-argument call to create.global.library can be made,
- and that a warning is thrown and no library-directory is constructed
  when a non-writeable directory is supplied.

Also,

- rewrote the code that constructs `R_lib_parent` to use
  `dirname(R.home())` for brevity,
- changed the `cat(...)` calls to `message(...)` so that the user can
  suppress them if required.