### PR TITLE
fix #137 : add appveyor integration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,8 @@ Authors@R: c(person("Tal", "Galili", role = c("aut", "cre", "cph"), email =
     person("Jonathan", "Hill", email = "jon.mark.hill@gmail.com", role = "ctb"),
     person("Chan-Yub", "Park", email = "mrchypark@gmail.com",
     comment = "https://github.com/mrchypark", role = "ctb"),
-    person("Gerhard", "Nachtmann", email = "kpm.nachtmann@gmail.com", role = "ctb")
+    person("Gerhard", "Nachtmann", email = "kpm.nachtmann@gmail.com", role = "ctb"),
+    person("Russ", "Hyde", email = "russ.hyde.data@gmail.com", role = "ctb")
     )
 Description: R is great for installing software.  Through the 'installr'
     package you can automate the updating of R (on Windows, using updateR())

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,6 +62,7 @@ Suggests:
     ggplot2,
     sp,
     tools,
-    pkgbuild
+    pkgbuild,
+    R.utils
 License: GPL-2
 RoxygenNote: 6.1.1

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 installr 0.22.1 (2019-08-16)
 ---------------------------
 
+OTHER NOTES:
+   * Appveyor integration added to the github repo
+
 BUG FIXES:
    * Fix install.GraphicsMagick
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
+<!-- badges: start -->
 [![Build Status](https://travis-ci.org/talgalili/installr.png?branch=master)](https://travis-ci.org/talgalili/installr)
 [![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/installr)](https://cran.r-project.org/package=installr)
+[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/talgalili/installr?branch=master&svg=true)](https://ci.appveyor.com/project/talgalili/installr)
 ![](http://cranlogs.r-pkg.org/badges/installr?color=yellow)
 ![](http://cranlogs.r-pkg.org/badges/grand-total/installr?color=yellowgreen)
-
+<!-- badges: end -->
 
 # installr
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,52 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  ps: Bootstrap
+
+cache:
+  - C:\RLibrary
+
+environment:
+  NOT_CRAN: true
+  # env vars that may need to be set, at least temporarily, from time to time
+  # see https://github.com/krlmlr/r-appveyor#readme for details
+  # USE_RTOOLS: true
+  # R_REMOTES_STANDALONE: true
+
+# Adapt as necessary starting from here
+
+build_script:
+  - travis-tool.sh install_deps
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits


### PR DESCRIPTION
# Description

This sets up a Windows-based CI platform for `installr` so that `R CMD check` and automated tests can be ran whenever someone makes a pull request.

Fixes #137 

## Type of change

New feature (non-breaking change which adds functionality)
- No source-code changes are introduced by this change-set

## Changes

- Appveyor config was created using `usethis::use_appveyor()`
- Appveyor badge was added to the README
- [Minor] Added 'R.utils' package to `DESCRIPTION::Suggests` since it was required for documentation cross-refs during R CMD check on appveyor and travis.

