### PR TITLE
fix to is.x64()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: installr
 Type: Package
 Title: Using R to Install Stuff on Windows OS (Such As: R, 'Rtools', 'RStudio', 'Git', and More!)
-Version: 0.22.1
-Date: 2019-08-16
+Version: 0.22.2
+Date: 2019-11-28
 Authors@R: c(person("Tal", "Galili", role = c("aut", "cre", "cph"), email =
     "tal.galili@gmail.com", comment = "http://www.r-statistics.com"),
     person("Barry", "Rowlingson", role = "ctb", email =

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+﻿installr 0.22.2 (2019-11-28)
+
+small edits to improve 32/64 bit architecture detection and appropriate download for Python.
+
+
 installr 0.22.0 (2019-08-02)
 ---------------------------
 

--- a/R/installPython.R
+++ b/R/installPython.R
@@ -26,7 +26,7 @@
 #' @export
 #' @author Tal Galili and A. Jonathan R. Godfrey
 #' @param page_with_download_url a link to the list of download links for Python
-#' @param x64 logical: fetch a 64 bit version. default checks architecture of current R session.
+#' @param x64 logical: fetch a 64 bit version. default is TRUE; used to check architecture of current R session.
 #' @param version_number Either 2 or 3. Version 2/3 will lead to download of v2.7.xx/3.6.xx respectively.
 #' @param ... extra parameters to pass to \link{install.URL}
 #' @examples
@@ -37,7 +37,7 @@
 #' }
 install.python = function (page_with_download_url = "https://www.python.org/downloads/windows/",
                            version_number = 3,
-                           x64 = is.x64(),
+                           x64 = TRUE,
                              ...)
 {
   page <- readLines(page_with_download_url, warn = FALSE)

--- a/R/is.x.R
+++ b/R/is.x.R
@@ -62,10 +62,9 @@ is.windows <- function(...) unname(Sys.info()["sysname"] == "Windows")
 #' @return Returns TRUE/FALSE if the R session is running on Windows 64-bit or not. 
 #' @export
 #' @examples
-#' \dontrun{
 #' is.x64() # returns TRUE on my machine.
-#' }
-is.x64 <- function(...) unname(Sys.info()["release"] == ">= 8 x64")
+
+is.x64 <- function(...)  .Platform$r_arch == "x64"
 
 
 #' @title Checks if the R session is running within RStudio

--- a/man/install.python.Rd
+++ b/man/install.python.Rd
@@ -6,14 +6,14 @@
 \usage{
 
   install.python(page_with_download_url = "https://www.python.org/downloads/windows/",
-  version_number = 3, x64 = is.x64(), ...)
+  version_number = 3, x64 = TRUE, ...)
 }
 \arguments{
 \item{page_with_download_url}{a link to the list of download links for Python}
 
 \item{version_number}{Either 2 or 3. Version 2/3 will lead to download of v2.7.xx/3.6.xx respectively.}
 
-\item{x64}{logical: fetch a 64 bit version. default checks architecture of current R session.}
+\item{x64}{logical: fetch a 64 bit version. default is TRUE; used to check architecture of current R session.}
 
 \item{...}{extra parameters to pass to \link{install.URL}}
 }

--- a/man/is.x64.Rd
+++ b/man/is.x64.Rd
@@ -20,7 +20,5 @@ This function is run when the 'installr' package is first loaded in order to che
 If you are running a different OS, then the installr package (at its current form) does not have much to offer you.
 }
 \examples{
-\dontrun{
 is.x64() # returns TRUE on my machine.
-}
 }


### PR DESCRIPTION
The details for "release" for the latest x64 version I used were different to the text specified in the is.x64() function. I altered it to hopefully is more future proof. You may decide not to allow the suggested change to the install.python() function but I think this should become the standard from here on, so that  the 32bit user has to take action, which should be extremely rare nowadays.