### PR TITLE
Fix typo in CMake example

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -1630,7 +1630,7 @@ package_authors <- function(package, to_strsplit = TRUE, split=c(",|and"), to_ta
 #' } 
 #' @examples
 #' \dontrun{
-#' install.CMake() # installs the latest version of ImageMagick
+#' install.CMake() # installs the latest version of CMake
 #' }
 #'
 install.CMake   <- function(URL="https://cmake.org/download/",...) {    

--- a/man/install.CMake.Rd
+++ b/man/install.CMake.Rd
@@ -27,7 +27,7 @@ compiler environment of your choice.
 }
 \examples{
 \dontrun{
-install.CMake() # installs the latest version of ImageMagick
+install.CMake() # installs the latest version of CMake
 }
 
 }


### PR DESCRIPTION
This fixes a minor typo in install.CMake documentation