### PR TITLE
Fix global-library deletion guard to check path count

### DIFF
--- a/R/create.global.library.R
+++ b/R/create.global.library.R
@@ -121,7 +121,22 @@ create.global.library <- function(global_library_folder)
    did_we_create_global_library_folder
 }
 
-
+# Internal helper that removes package folders from the global library.
+#
+# It only calls unlink() when there is at least one candidate path. This guards
+# against the previously buggy check `if (package.to.del.from.global.lib > 0)`
+# which (a) errored with "argument is of length zero" when the candidate vector
+# was empty (character(0)) and (b) only inspected the first element (with a
+# warning) when several paths were present.
+#
+# Returns (invisibly) the number of candidate paths that were removed.
+delete_packages_from_global_library <-
+   function(package.to.del.from.global.lib) {
+      if (length(package.to.del.from.global.lib) > 0) {
+         unlink(package.to.del.from.global.lib, recursive = TRUE)
+      }
+      invisible(length(package.to.del.from.global.lib))
+   }
 
 
 
@@ -256,10 +271,10 @@ xx.global.library <- function(
 
       package.to.del.from.global.lib <- packages_in_libs_to_move
 
-      number.of.packages.we.will.delete <- length(package.to.del.from.global.lib)
-      if(package.to.del.from.global.lib >0 ) {
+      number.of.packages.we.will.delete <-
+         delete_packages_from_global_library(package.to.del.from.global.lib)
+      if(number.of.packages.we.will.delete > 0) {
          # maybe add a user input here...
-         deleted.packages <- unlink(package.to.del.from.global.lib , recursive = TRUE)   # delete all the packages from the "original" library folder (no need for double folders)
          cat(paste(number.of.packages.we.will.delete,"Packages where deleted."),"\n")
       }
    }

--- a/tests/testthat/test-delete_packages_from_global_library.R
+++ b/tests/testthat/test-delete_packages_from_global_library.R
@@ -1,0 +1,56 @@
+context("Test deletion of packages from the global-library (length guard)")
+
+# Regression tests for the guard that protects the recursive unlink() used when
+# removing packages from the global library.
+#
+# The original code used `if (package.to.del.from.global.lib > 0)` on a
+# character vector of candidate paths. That guard:
+#   * errored with "argument is of length zero" when no packages matched
+#     (i.e. the vector was character(0)), and
+#   * only inspected the first element (with a "condition has length > 1"
+#     warning) when several paths were present.
+# The fix checks `length(package.to.del.from.global.lib) > 0` instead. These
+# tests exercise zero, one and multiple candidate paths using temporary
+# directories so that no real files are ever at risk.
+
+test_that("delete_packages_from_global_library does not error on zero candidates", {
+   # character(0) must return cleanly (the old guard errored here).
+   expect_silent(
+      out <- installr:::delete_packages_from_global_library(character(0))
+   )
+   expect_equal(out, 0)
+})
+
+test_that("delete_packages_from_global_library deletes a single candidate path", {
+   td <- tempfile()
+   dir.create(td)
+   on.exit(unlink(td, recursive = TRUE), add = TRUE)
+
+   pkg <- file.path(td, "pkgA")
+   dir.create(pkg)
+   stopifnot(dir.exists(pkg))
+
+   expect_equal(
+      installr:::delete_packages_from_global_library(pkg),
+      1
+   )
+   expect_false(dir.exists(pkg))
+})
+
+test_that("delete_packages_from_global_library deletes multiple candidate paths", {
+   td <- tempfile()
+   dir.create(td)
+   on.exit(unlink(td, recursive = TRUE), add = TRUE)
+
+   to_delete <- file.path(td, c("pkgA", "pkgB", "pkgC"))
+   keep <- file.path(td, "pkgKeep")
+   for (d in c(to_delete, keep)) dir.create(d)
+   stopifnot(all(dir.exists(c(to_delete, keep))))
+
+   expect_equal(
+      installr:::delete_packages_from_global_library(to_delete),
+      3
+   )
+   expect_false(any(dir.exists(to_delete)))
+   expect_true(dir.exists(keep))
+})


### PR DESCRIPTION
The recursive unlink() in xx.global.library was guarded by `if (package.to.del.from.global.lib > 0)`, which compared a character vector of candidate paths to 0. This errored with "argument is of length zero" when no packages matched (character(0)) and, on R >= 4.2, errored with "the condition has length > 1" when several paths were present.

Extract the guarded deletion into delete_packages_from_global_library(), which checks `length(...) > 0`, and add regression tests covering zero, one and multiple candidate paths using temporary directories.

Found during my large https://github.com/sims1253/ry audit